### PR TITLE
feat: add SEO-optimized HTML version of privacy policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated: 2025-09-30
+Last updated: 2025-10-01
 
 All notable changes to X-Proxy Chrome Extension will be documented in this file.
 
@@ -16,6 +16,28 @@ Future improvements planned:
 - Blog content creation for SEO
 - Multi-language support (Chinese, Japanese, Russian)
 - Google Analytics integration
+
+## [1.1.1] - 2025-10-01
+
+### Enhanced - Privacy Policy Page SEO
+- **Privacy Policy HTML Version**
+  - Created SEO-optimized HTML version of privacy policy (`docs/PRIVACY_POLICY/index.html`)
+  - Added comprehensive meta tags (title, description, Open Graph, Twitter Card)
+  - Implemented consistent header/footer styling with main site
+  - Added breadcrumb navigation for improved UX and SEO
+  - Ensured mobile responsiveness and accessibility
+
+- **Content Organization**
+  - Preserved Markdown source as `policy.md` for easy maintenance
+  - Applied highlight boxes for key privacy statements
+  - Improved content hierarchy with proper heading structure
+  - Enhanced link accessibility with rel="noopener" for external links
+
+- **SEO Benefits**
+  - Independent meta tag control for search engines
+  - Unified design language across all GitHub Pages
+  - Better discoverability through optimized meta descriptions
+  - Improved user experience with consistent navigation
 
 ## [1.1.0] - 2025-09-30
 

--- a/docs/PRIVACY_POLICY/index.html
+++ b/docs/PRIVACY_POLICY/index.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - X-Proxy Chrome Extension</title>
+    <meta name="description" content="X-Proxy privacy policy. We respect your privacy: all data stored locally, no tracking, no external servers. Read our complete privacy policy and data practices.">
+    <meta name="keywords" content="x-proxy privacy policy, chrome extension privacy, data protection, local storage, no tracking">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://helebest.github.io/x-proxy/PRIVACY_POLICY/">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://helebest.github.io/x-proxy/PRIVACY_POLICY/">
+    <meta property="og:title" content="Privacy Policy - X-Proxy">
+    <meta property="og:description" content="X-Proxy privacy policy: All data stored locally, no tracking, no external servers.">
+    <meta property="og:image" content="https://helebest.github.io/x-proxy/icons/icon-128.png">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:url" content="https://helebest.github.io/x-proxy/PRIVACY_POLICY/">
+    <meta name="twitter:title" content="Privacy Policy - X-Proxy">
+    <meta name="twitter:description" content="X-Proxy privacy policy: All data stored locally, no tracking, no external servers.">
+    <meta name="twitter:image" content="https://helebest.github.io/x-proxy/icons/icon-128.png">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="32x32" href="../icons/icon-32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../icons/icon-16.png">
+
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="../assets/css/style.css">
+
+    <style>
+        body { opacity: 0; }
+        body.loaded { opacity: 1; transition: opacity 0.3s; }
+
+        .privacy-content {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 120px 20px 80px;
+            line-height: 1.8;
+        }
+
+        .breadcrumb {
+            margin-bottom: 2rem;
+            font-size: 0.9rem;
+            color: var(--gray);
+        }
+
+        .breadcrumb a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .privacy-content h1 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            color: var(--dark);
+        }
+
+        .last-updated {
+            color: var(--gray);
+            font-size: 0.9rem;
+            margin-bottom: 2rem;
+        }
+
+        .privacy-content h2 {
+            font-size: 1.8rem;
+            margin-top: 3rem;
+            margin-bottom: 1rem;
+            color: var(--dark);
+            border-bottom: 2px solid var(--light);
+            padding-bottom: 0.5rem;
+        }
+
+        .privacy-content h3 {
+            font-size: 1.3rem;
+            margin-top: 2rem;
+            margin-bottom: 0.5rem;
+            color: var(--primary);
+        }
+
+        .privacy-content p {
+            margin-bottom: 1rem;
+            color: var(--dark);
+        }
+
+        .privacy-content ul, .privacy-content ol {
+            margin-bottom: 1.5rem;
+            padding-left: 2rem;
+        }
+
+        .privacy-content li {
+            margin-bottom: 0.5rem;
+            color: var(--dark);
+        }
+
+        .privacy-content strong {
+            color: var(--primary);
+            font-weight: 600;
+        }
+
+        .privacy-content a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        .privacy-content a:hover {
+            text-decoration: underline;
+        }
+
+        .highlight-box {
+            background: var(--light);
+            border-left: 4px solid var(--primary);
+            padding: 1.5rem;
+            margin: 2rem 0;
+            border-radius: 4px;
+        }
+
+        .highlight-box strong {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-size: 1.1rem;
+        }
+
+        footer {
+            margin-top: 4rem;
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <nav class="container">
+            <a href="../" class="logo">
+                <img src="../icons/icon-32.png" alt="X-Proxy Logo">
+                X-Proxy
+            </a>
+            <ul class="nav-links">
+                <li><a href="../#features">Features</a></li>
+                <li><a href="../#installation">Installation</a></li>
+                <li><a href="./">Privacy</a></li>
+                <li><a href="https://github.com/helebest/x-proxy" target="_blank">GitHub</a></li>
+            </ul>
+            <a href="../#installation" class="cta-button">Get Started</a>
+        </nav>
+    </header>
+
+    <!-- Privacy Policy Content -->
+    <div class="privacy-content">
+        <!-- Breadcrumb -->
+        <nav class="breadcrumb">
+            <a href="../">Home</a> / Privacy Policy
+        </nav>
+
+        <h1>Privacy Policy for X-Proxy Chrome Extension</h1>
+        <p class="last-updated"><strong>Last updated:</strong> August 21, 2025</p>
+
+        <h2>Overview</h2>
+        <p>X-Proxy ("we," "our," or "us") respects your privacy and is committed to protecting your personal information. This privacy policy explains how our Chrome extension collects, uses, stores, and protects your information when you use the X-Proxy extension.</p>
+
+        <h2>Information We Collect</h2>
+
+        <h3>Proxy Configuration Data</h3>
+        <p>X-Proxy collects and stores the following information that you provide:</p>
+        <ul>
+            <li><strong>Proxy Server Details:</strong> Server addresses (hostnames/IP addresses), port numbers, and authentication credentials (usernames and passwords) for your proxy configurations</li>
+            <li><strong>Profile Information:</strong> Names and descriptions you assign to your proxy profiles for organization purposes</li>
+            <li><strong>Connection Settings:</strong> Proxy types (HTTP, HTTPS, SOCKS5) and related configuration parameters</li>
+        </ul>
+
+        <h3>Application Preferences</h3>
+        <ul>
+            <li><strong>User Interface Settings:</strong> Theme preferences, layout choices, and other customization options</li>
+            <li><strong>Extension State:</strong> Currently active proxy profile and connection status</li>
+            <li><strong>Usage Preferences:</strong> Settings related to automatic connection, profile organization, and other user-defined preferences</li>
+        </ul>
+
+        <h2>How We Use Your Information</h2>
+        <p>X-Proxy uses your information solely to provide the core functionality of the extension:</p>
+        <ul>
+            <li><strong>Proxy Management:</strong> To configure, activate, and manage your proxy connections through Chrome's proxy API</li>
+            <li><strong>Profile Storage:</strong> To save and organize your proxy configurations for future use</li>
+            <li><strong>State Management:</strong> To remember your active proxy settings and preferences across browser sessions</li>
+            <li><strong>User Interface:</strong> To display your proxy profiles and current connection status</li>
+        </ul>
+
+        <h2>Data Storage and Security</h2>
+
+        <div class="highlight-box">
+            <strong>Local Storage Only</strong>
+            <p>All data is stored locally on your device using Chrome's secure storage API. Your proxy configurations, credentials, and preferences are never transmitted to external servers, third parties, or our systems.</p>
+        </div>
+
+        <h3>Security Measures</h3>
+        <ul>
+            <li><strong>Chrome's Security:</strong> Data is protected using Chrome's built-in storage security mechanisms</li>
+            <li><strong>No External Access:</strong> The extension does not communicate with external servers or APIs for data storage</li>
+            <li><strong>Local Storage Only:</strong> Data stored in chrome.storage.local</li>
+        </ul>
+
+        <h3>Important Security Considerations</h3>
+        <ul>
+            <li><strong>Proxy Credentials:</strong> Authentication credentials (usernames/passwords) are stored in plaintext in local browser storage. Users should:
+                <ul>
+                    <li>Use unique, strong passwords for proxy authentication</li>
+                    <li>Regularly rotate proxy credentials</li>
+                    <li>Avoid using personal/primary account passwords</li>
+                </ul>
+            </li>
+            <li><strong>Browser Sync Risk:</strong> If Chrome sync is enabled, extension data may be synchronized across your Google-linked devices and stored on Google's servers</li>
+            <li><strong>Local Access:</strong> Other extensions with storage permissions or local malware could potentially access stored proxy configurations</li>
+            <li><strong>Device Security:</strong> On shared or compromised devices, proxy configurations may be accessible to other users</li>
+        </ul>
+
+        <h3>User Security Recommendations</h3>
+        <ul>
+            <li>Use the extension only on trusted, secure devices</li>
+            <li>Enable device-level disk encryption for additional protection</li>
+            <li>Consider disabling Chrome sync for sensitive proxy configurations</li>
+            <li>Regularly review and clean stored proxy profiles</li>
+            <li>Log out of shared devices and clear browser data when necessary</li>
+        </ul>
+
+        <h2>Permissions Explanation</h2>
+        <p>X-Proxy requests the following permissions, which are essential for its functionality:</p>
+
+        <h3>"proxy" Permission</h3>
+        <ul>
+            <li><strong>Purpose:</strong> Required to modify Chrome's proxy settings and route your internet traffic through the configured proxy servers</li>
+            <li><strong>Usage:</strong> Activated only when you select a proxy profile; automatically disabled when you choose "System Proxy"</li>
+        </ul>
+
+        <h3>"storage" Permission</h3>
+        <ul>
+            <li><strong>Purpose:</strong> Required to save your proxy profiles, preferences, and settings locally on your device</li>
+            <li><strong>Usage:</strong> Used to persist your configurations between browser sessions</li>
+        </ul>
+
+        <h3>Host Permissions ("<all_urls>")</h3>
+        <ul>
+            <li><strong>Purpose:</strong> Required to apply proxy settings to all websites you visit</li>
+            <li><strong>Usage:</strong> Necessary for the proxy to function across all web traffic as intended</li>
+            <li><strong>Note:</strong> This permission does not allow the extension to access, read, or modify website content</li>
+        </ul>
+
+        <h2>Data Sharing and Disclosure</h2>
+        <div class="highlight-box">
+            <strong>We do not share your information.</strong>
+            <p>Your proxy configurations and personal data are never shared with third parties. We do not collect usage analytics, telemetry data, or use your data for advertising purposes.</p>
+        </div>
+
+        <h2>Your Rights and Control</h2>
+        <p>You have complete control over your data:</p>
+        <ul>
+            <li><strong>View Data:</strong> You can view all stored data through the extension's options page</li>
+            <li><strong>Modify Data:</strong> You can edit or update any proxy profiles and settings at any time</li>
+            <li><strong>Delete Data:</strong> You can delete individual profiles or clear all extension data</li>
+            <li><strong>Export Data:</strong> You can manually export your configurations if needed</li>
+            <li><strong>Complete Removal:</strong> Uninstalling the extension will remove all stored data from your device</li>
+        </ul>
+
+        <h2>Changes to Proxy Settings</h2>
+        <p>When you use X-Proxy:</p>
+        <ul>
+            <li><strong>Temporary Changes:</strong> Proxy settings only affect your current browser session</li>
+            <li><strong>Manual Control:</strong> You must manually activate proxy profiles; the extension does not automatically change your proxy settings</li>
+            <li><strong>Easy Restoration:</strong> You can return to your original internet connection by selecting "System Proxy"</li>
+        </ul>
+
+        <h2>Data Retention</h2>
+        <ul>
+            <li><strong>User-Controlled:</strong> Data is retained only as long as you keep the extension installed</li>
+            <li><strong>No Automatic Deletion:</strong> Your configurations persist until you manually delete them or uninstall the extension</li>
+            <li><strong>Complete Removal:</strong> Uninstalling the extension removes all associated data from your device</li>
+        </ul>
+
+        <h2>Third-Party Services</h2>
+        <p>X-Proxy does not integrate with or send data to any third-party services. The extension operates entirely locally on your device.</p>
+
+        <h2>Contact Information</h2>
+        <p>If you have questions about this privacy policy or the X-Proxy extension, you can:</p>
+        <ul>
+            <li><strong>Report Issues:</strong> <a href="https://github.com/helebest/x-proxy/issues" target="_blank" rel="noopener">GitHub Issues</a></li>
+            <li><strong>View Source Code:</strong> <a href="https://github.com/helebest/x-proxy" target="_blank" rel="noopener">GitHub Repository</a></li>
+        </ul>
+
+        <h2>Policy Updates</h2>
+        <p>We may update this privacy policy to reflect changes in our practices or for legal, operational, or regulatory reasons. Updates will be posted with a new "Last updated" date. Continued use of the extension after updates constitutes acceptance of the revised policy.</p>
+
+        <h2>Compliance</h2>
+        <p>This privacy policy complies with:</p>
+        <ul>
+            <li>Chrome Web Store Developer Program Policies</li>
+            <li>General Data Protection Regulation (GDPR) requirements</li>
+            <li>California Consumer Privacy Act (CCPA) guidelines</li>
+        </ul>
+
+        <hr style="margin: 3rem 0; border: none; border-top: 1px solid var(--light);">
+
+        <div class="highlight-box">
+            <strong>Summary</strong>
+            <p>X-Proxy is designed with privacy in mind. All your proxy configurations and settings are stored locally on your device and are never transmitted to external servers. The extension only uses the minimum permissions necessary to provide proxy switching functionality, and you maintain complete control over your data at all times.</p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>Extension</h4>
+                    <ul>
+                        <li><a href="https://chromewebstore.google.com/detail/x-proxy/efbckpjdlnojgnggdilgddeemgkoccaf" target="_blank" rel="noopener">Chrome Web Store</a></li>
+                        <li><a href="../#features">Features</a></li>
+                        <li><a href="../#installation">Installation</a></li>
+                        <li><a href="https://github.com/helebest/x-proxy/releases" target="_blank" rel="noopener">Releases</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>Development</h4>
+                    <ul>
+                        <li><a href="https://github.com/helebest/x-proxy" target="_blank" rel="noopener">Source Code</a></li>
+                        <li><a href="https://github.com/helebest/x-proxy/issues" target="_blank" rel="noopener">Issues</a></li>
+                        <li><a href="https://github.com/helebest/x-proxy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>Legal</h4>
+                    <ul>
+                        <li><a href="./">Privacy Policy</a></li>
+                        <li><a href="https://github.com/helebest/x-proxy/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>Support</h4>
+                    <ul>
+                        <li><a href="https://github.com/helebest/x-proxy/issues" target="_blank" rel="noopener">Report Issues</a></li>
+                        <li><a href="https://github.com/helebest/x-proxy/discussions" target="_blank" rel="noopener">Discussions</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 X-Proxy. Simple, reliable proxy switching for Chrome. MIT Licensed.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        // Page load animation
+        window.addEventListener('load', () => {
+            document.body.classList.add('loaded');
+        });
+
+        // Smooth scrolling for anchor links
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function (e) {
+                e.preventDefault();
+                const target = document.querySelector(this.getAttribute('href'));
+                if (target) {
+                    const headerOffset = 80;
+                    const elementPosition = target.offsetTop;
+                    const offsetPosition = elementPosition - headerOffset;
+                    window.scrollTo({
+                        top: offsetPosition,
+                        behavior: 'smooth'
+                    });
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,7 +7,7 @@
     <!-- Homepage - Highest Priority -->
     <url>
         <loc>https://helebest.github.io/x-proxy/</loc>
-        <lastmod>2025-09-30</lastmod>
+        <lastmod>2025-10-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
@@ -15,9 +15,9 @@
     <!-- Privacy Policy -->
     <url>
         <loc>https://helebest.github.io/x-proxy/PRIVACY_POLICY/</loc>
-        <lastmod>2025-09-30</lastmod>
+        <lastmod>2025-10-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.6</priority>
+        <priority>0.7</priority>
     </url>
 
     <!-- GitHub Repository -->


### PR DESCRIPTION
- Create docs/PRIVACY_POLICY/index.html with full SEO optimization
- Add comprehensive meta tags (title, description, OG, Twitter Card)
- Implement consistent header/footer styling with main site
- Add breadcrumb navigation for better UX and SEO
- Apply highlight boxes for key privacy statements
- Ensure mobile responsiveness and accessibility
- Keep index.md as content source and backup

SEO Improvements:
- Independent meta tag control for search engines
- Canonical URL and proper Open Graph tags
- Unified design language across GitHub Pages
- Better discoverability through optimized meta descriptions

GitHub Pages will prioritize index.html over index.md when both exist, ensuring the SEO-optimized version is served while maintaining the Markdown source for easy content updates.

Updated sitemap.xml lastmod dates and increased privacy policy priority.

🤖 Generated with [Claude Code](https://claude.ai/code)