### PR TITLE
fix: correct privacy policy list alignment from center to left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Future improvements planned:
   - Better discoverability through optimized meta descriptions
   - Improved user experience with consistent navigation
 
+### Fixed
+- **Privacy Policy List Alignment**
+  - Corrected list items alignment from center to left for better readability
+  - Updated `docs/PRIVACY_POLICY/index.html` inline styles
+  - Updated `docs/assets/css/style.css` for consistent alignment
+
 ## [1.1.0] - 2025-09-30
 
 ### Added - GitHub Pages SEO & UI Optimization

--- a/docs/PRIVACY_POLICY/index.html
+++ b/docs/PRIVACY_POLICY/index.html
@@ -40,6 +40,7 @@
             margin: 0 auto;
             padding: 120px 20px 80px;
             line-height: 1.8;
+            text-align: left;
         }
 
         .breadcrumb {

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -314,7 +314,7 @@ nav {
 .privacy-content {
     max-width: 800px;
     margin: 0 auto;
-    text-align: center;
+    text-align: left;
 }
 
 .privacy-features {


### PR DESCRIPTION
Changed text-align from center to left for better readability of list items in the privacy policy page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)