### PR TITLE
fix: enhance domain validation for blacklist mode (Issue #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated: 2025-12-27
+Last updated: 2025-12-29
 
 All notable changes to X-Proxy Chrome Extension will be documented in this file.
 
@@ -16,6 +16,19 @@ Future improvements planned:
 - Blog content creation for SEO
 - Multi-language support (Chinese, Japanese, Russian)
 - Google Analytics integration
+
+## [1.3.1] - 2025-12-29
+
+### Fixed - Domain Validation Bug (Issue #9)
+- **Enhanced `isValidDomain()` method**
+  - Added IPv4 address support (e.g., `127.0.0.1`, `192.168.*`, `10.0.0.0/24`)
+  - Added IPv6 address support (e.g., `::1`, `fe80::1`)
+  - Added simple hostname support (e.g., `localhost`)
+  - Added single-level wildcard support (e.g., `*.local`)
+  - Fixed: blacklist domains like `localhost`, `127.0.0.1` can now be saved
+
+### Credits
+- Thanks to [@jasonliaotw](https://github.com/jasonliaotw) for reporting the issue and contributing the regex patterns
 
 ## [1.3.0] - 2025-12-27
 

--- a/README.md
+++ b/README.md
@@ -311,11 +311,16 @@ If you find X-Proxy useful, consider:
 - [x] Profile-level routing configuration
 - [x] Automatic PAC script generation
 
-### v1.3.0 ✅ (Current - Bypass List)
+### v1.3.0 ✅ (Bypass List)
 - [x] Whitelist/Blacklist mode selection (Issue #6)
 - [x] Dynamic UI based on routing mode
 - [x] Enhanced PAC script for blacklist mode
 - [x] Backward compatible with existing profiles
+
+### v1.3.1 ✅ (Current - Bug Fix)
+- [x] Fixed domain validation for blacklist mode (Issue #9)
+- [x] Added IPv4/IPv6 address support in routing rules
+- [x] Added localhost and simple hostname support
 
 ### v1.4.0 (Planned)
 - [ ] Import/export profiles (JSON format)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "X-Proxy",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A modern proxy switcher for Chrome with HTTP(S) and SOCKS5 support",
   "permissions": [
     "proxy",

--- a/options.html
+++ b/options.html
@@ -65,7 +65,7 @@
             </div>
             
             <div class="about-info">
-              <h3>X-Proxy v1.3.0</h3>
+              <h3>X-Proxy v1.3.1</h3>
               <p>A modern proxy switcher for Chrome with HTTP(S) and SOCKS5 support</p>
               
               <div class="about-details">

--- a/options.js
+++ b/options.js
@@ -387,11 +387,22 @@ class OptionsManager {
     document.getElementById('proxyDetails').style.display = 'block';
   }
 
-  // Validate domain format (supports wildcards)
+  // Validate domain/IP format (supports wildcards, CIDR, localhost, etc.)
+  // Credit: Pattern contributed by @jasonliaotw in issue #9
   isValidDomain(domain) {
-    // Allow wildcard patterns like *.google.com or just *
-    const pattern = /^(\*\.)?([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$/;
-    return pattern.test(domain) || domain === '*';
+    // IPv4 address with optional wildcard segments or CIDR notation
+    // Examples: 127.0.0.1, 192.168.*, 192.168.0.0/24, 10.*
+    const ipv4Pattern = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d|\*)){0,3}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)\/(?:[0-9]|[1-2][0-9]|3[0-2]))$/;
+
+    // IPv6 address (simplified pattern for common formats)
+    // Examples: ::1, fe80::1, 2001:db8::1
+    const ipv6Pattern = /^(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}(?:\/\d{1,3})?$/;
+
+    // Domain name pattern (supports wildcards, localhost, *.local, etc.)
+    // Examples: localhost, *.google.com, github.com, *.local, example.*
+    const domainPattern = /^(?:\*|(?:\*\.)?[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(?:\.\*)?)$/;
+
+    return ipv4Pattern.test(domain) || ipv6Pattern.test(domain) || domainPattern.test(domain);
   }
 
   // Update the domain list label and placeholder based on routing mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-proxy",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Fixed domain validation bug that prevented saving blacklist domains like `localhost`, `127.0.0.1`
- Enhanced `isValidDomain()` method with comprehensive pattern support
- Bumped version to 1.3.1

## Changes

### Bug Fix (Issue #9)
- **IPv4 support**: `127.0.0.1`, `192.168.*`, `10.0.0.0/24`
- **IPv6 support**: `::1`, `fe80::1`
- **Hostname support**: `localhost`, `*.local`
- **Wildcard patterns**: `*.google.com`, `example.*`

### Version Update
- Updated version to 1.3.1 in manifest.json, package.json, options.html
- Updated CHANGELOG.md and README.md roadmap

## Credits

Thanks to [@jasonliaotw](https://github.com/jasonliaotw) for reporting the issue and contributing the regex patterns.

## Test plan
- [x] Create profile with blacklist mode
- [x] Add domains: `localhost`, `127.0.0.1`, `192.168.*`, `*.local`
- [x] Verify profile saves successfully
- [x] Verify About page shows v1.3.1

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)