### PR TITLE
feat: add proxy authentication support (Issue #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ Future improvements planned:
 - Blog content creation for SEO
 - Multi-language support (Chinese, Japanese, Russian)
 
+## [1.4.2] - 2026-03-14
+
+### Added - Proxy Authentication (Issue #17)
+- **Username/Password authentication for proxy servers**
+  - Optional username and password fields in profile configuration
+  - Handled via `chrome.webRequest.onAuthRequired` (Manifest V3)
+  - Works with both HTTP/HTTPS and SOCKS5 proxy types
+  - Credentials stored locally, never transmitted externally
+- **New permissions**: `webRequest`, `webRequestAuthProvider`
+- **Unit Tests**: auth normalization tests + auth handler tests (TDD)
+
 ## [1.4.1] - 2026-03-09
 
 ### Fixed - Domain Routing Bug

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Managing multiple proxy configurations shouldn't be complicated. X-Proxy makes i
 - **⚡ Instant Switching**: Activate profiles with a single click from toolbar
 - **🎯 Domain Routing**: Configure specific domains to use proxy (whitelist mode)
 - **🔧 System Integration**: Seamless Chrome proxy API integration
+- **🔐 Proxy Authentication**: Username/password support for authenticated proxies
 - **📤 Import/Export**: Backup and restore proxy configurations as JSON
 - **💾 Local Storage**: All data stays on your device, no cloud sync
 
@@ -329,6 +330,11 @@ If you find X-Proxy useful, consider:
 - [x] Fixed domain routing bug (missing `mode` in normalization)
 - [x] Added unit tests for normalization and PAC script generation
 - [x] Configured vitest with real test scripts
+
+### v1.4.2 ✅ (Proxy Authentication)
+- [x] Username/password authentication for proxy servers (Issue #17)
+- [x] `chrome.webRequest.onAuthRequired` handler
+- [x] Auth normalization and handler unit tests (TDD)
 
 ### v2.0.0 (Future)
 - [ ] Profile sharing via URL

--- a/background.js
+++ b/background.js
@@ -299,6 +299,51 @@ chrome.runtime.onStartup.addListener(() => {
   initializeProxyState();
 });
 
+// Handle proxy authentication requests
+// Uses asyncBlocking because service worker may restart and lose in-memory activeProfile
+chrome.webRequest.onAuthRequired.addListener(
+  (details, asyncCallback) => {
+    if (!details.isProxy) {
+      asyncCallback({});
+      return;
+    }
+
+    // Try in-memory profile first (fast path)
+    if (activeProfile) {
+      const auth = activeProfile.config?.auth;
+      if (auth && auth.username) {
+        console.log('Auth provided from memory for:', activeProfile.name);
+        asyncCallback({ authCredentials: { username: auth.username, password: auth.password } });
+        return;
+      }
+      asyncCallback({});
+      return;
+    }
+
+    // Fallback: read from storage (service worker may have restarted)
+    chrome.storage.local.get(['x-proxy-data']).then(result => {
+      const data = result['x-proxy-data'] || {};
+      if (data.activeProfileId && data.profiles) {
+        const profile = data.profiles.find(p => p.id === data.activeProfileId);
+        if (profile) {
+          activeProfile = profile; // Restore in-memory state
+          const auth = profile.config?.auth;
+          if (auth && auth.username) {
+            console.log('Auth provided from storage for:', profile.name);
+            asyncCallback({ authCredentials: { username: auth.username, password: auth.password } });
+            return;
+          }
+        }
+      }
+      asyncCallback({});
+    }).catch(() => {
+      asyncCallback({});
+    });
+  },
+  { urls: ["<all_urls>"] },
+  ["asyncBlocking"]
+);
+
 // Handle messages from popup and options with improved error handling
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   console.log('Background received message:', request);

--- a/docs/index.html
+++ b/docs/index.html
@@ -697,6 +697,11 @@
                     <p>All data stored securely on your device. No external servers, no data transmission.</p>
                 </div>
                 <div class="feature-card">
+                    <div class="feature-icon">🔐</div>
+                    <h3>Proxy Authentication</h3>
+                    <p>Username and password support for authenticated proxy servers. Works with both HTTP/HTTPS and SOCKS5 proxies.</p>
+                </div>
+                <div class="feature-card">
                     <div class="feature-icon">📤</div>
                     <h3>Import & Export</h3>
                     <p>Backup and restore your proxy profiles as JSON. Share configurations across devices or with your team.</p>

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,13 @@
 {
   "manifest_version": 3,
   "name": "X-Proxy",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A modern proxy switcher for Chrome with HTTP(S) and SOCKS5 support",
   "permissions": [
     "proxy",
-    "storage"
+    "storage",
+    "webRequest",
+    "webRequestAuthProvider"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/options.css
+++ b/options.css
@@ -537,6 +537,36 @@ html {
   font-family: 'Courier New', monospace;
 }
 
+.password-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.password-label-row label {
+  margin-bottom: 0;
+}
+
+.password-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: var(--transition);
+}
+
+.password-toggle:hover {
+  color: var(--primary-color);
+  background: rgba(0, 0, 0, 0.05);
+}
+
 .form-help {
   display: block;
   margin-top: 4px;

--- a/options.html
+++ b/options.html
@@ -69,7 +69,7 @@
             </div>
             
             <div class="about-info">
-              <h3>X-Proxy v1.4.1</h3>
+              <h3>X-Proxy v1.4.2</h3>
               <p>A modern proxy switcher for Chrome with HTTP(S) and SOCKS5 support</p>
               
               <div class="about-details">
@@ -80,6 +80,7 @@
                   <li>✓ System proxy integration</li>
                   <li>✓ Simple profile management</li>
                   <li>✓ Import/Export profiles</li>
+                  <li>✓ Proxy authentication (username/password)</li>
                 </ul>
               </div>
               
@@ -169,6 +170,37 @@
             <div class="form-group">
               <label for="proxyPort">Port *</label>
               <input type="number" id="proxyPort" class="form-input" placeholder="8080" required>
+            </div>
+          </div>
+
+          <!-- Authentication (Optional) -->
+          <div class="form-section">
+            <div class="form-section-header">
+              <h4>Authentication (Optional)</h4>
+            </div>
+            <div class="form-group">
+              <label for="proxyUsername">Username</label>
+              <input type="text" id="proxyUsername" class="form-input"
+                     placeholder="Leave empty if not required" autocomplete="off">
+            </div>
+            <div class="form-group">
+              <div class="password-label-row">
+                <label for="proxyPassword">Password</label>
+                <button type="button" id="togglePassword" class="password-toggle">
+                  <svg id="eyeIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                    <circle cx="12" cy="12" r="3"></circle>
+                  </svg>
+                  <svg id="eyeOffIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"></path>
+                    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"></path>
+                    <line x1="1" y1="1" x2="23" y2="23"></line>
+                  </svg>
+                  <span id="toggleText">Show</span>
+                </button>
+              </div>
+              <input type="password" id="proxyPassword" class="form-input"
+                     placeholder="Leave empty if not required" autocomplete="off">
             </div>
           </div>
 

--- a/options.js
+++ b/options.js
@@ -73,6 +73,7 @@ class OptionsManager {
         type: profile.type || 'http',
         host: profile.host || '',
         port: parseInt(profile.port) || 8080,
+        auth: profile.config?.auth || { username: '', password: '' },
         bypassList: profile.bypassList || [],
         routingRules: profile.config?.routingRules || {
           enabled: false,
@@ -139,6 +140,7 @@ class OptionsManager {
         type: config.type || profile.type || 'http',
         host: config.host || profile.host || '',
         port: parseInt(config.port || profile.port) || 8080,
+        auth: config.auth || { username: '', password: '' },
         bypassList: config.bypassList || profile.bypassList || [],
         routingRules: config.routingRules || profile.routingRules || {
           enabled: false,
@@ -182,6 +184,16 @@ class OptionsManager {
 
     // Proxy type change handler
     document.getElementById('proxyType').addEventListener('change', (e) => this.handleProxyTypeChange(e));
+
+    // Password visibility toggle
+    document.getElementById('togglePassword').addEventListener('click', () => {
+      const input = document.getElementById('proxyPassword');
+      const isPassword = input.type === 'password';
+      input.type = isPassword ? 'text' : 'password';
+      document.getElementById('eyeIcon').style.display = isPassword ? 'none' : 'inline';
+      document.getElementById('eyeOffIcon').style.display = isPassword ? 'inline' : 'none';
+      document.getElementById('toggleText').textContent = isPassword ? 'Hide' : 'Show';
+    });
 
     // Routing rules toggle
     document.getElementById('enableRoutingRules').addEventListener('change', (e) => {
@@ -367,6 +379,11 @@ class OptionsManager {
       this.updateDomainListLabel(routingMode);
 
       document.getElementById('domainListTextarea').value = (routingRules.domains || []).join('\n');
+
+      // Load auth fields
+      const auth = config.auth || { username: '', password: '' };
+      document.getElementById('proxyUsername').value = auth.username || '';
+      document.getElementById('proxyPassword').value = auth.password || '';
     } else {
       title.textContent = 'Add Proxy Profile';
       document.getElementById('profileForm').reset();
@@ -464,6 +481,10 @@ github.com
       return;
     }
 
+    // Collect auth credentials
+    const username = document.getElementById('proxyUsername').value.trim();
+    const password = document.getElementById('proxyPassword').value;
+
     // Create profile with correct nested structure
     const profile = {
       id: this.editingProfile?.id || Date.now().toString(),
@@ -473,6 +494,7 @@ github.com
         type: type,
         host: host,
         port: parseInt(port),
+        auth: { username, password },
         bypassList: this.editingProfile?.config?.bypassList || [],
         routingRules: {
           enabled: routingEnabled,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x-proxy",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x-proxy",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -2249,9 +2249,9 @@
       "license": "MIT"
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-proxy",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/popup.js
+++ b/popup.js
@@ -127,12 +127,8 @@ function normalizeProfile(profile) {
             type: profile.type || 'http',
             host: profile.host || '',
             port: parseInt(profile.port) || 8080,
-            auth: profile.auth ? {
-                username: profile.username || '',
-                password: profile.password || ''
-            } : undefined,
+            auth: profile.config?.auth || { username: '', password: '' },
             bypassList: profile.bypassList || [],
-            pacUrl: profile.pacUrl,
             routingRules: profile.config?.routingRules || {
                 enabled: false,
                 mode: 'whitelist',

--- a/scripts/test-auth-proxy.js
+++ b/scripts/test-auth-proxy.js
@@ -1,0 +1,121 @@
+/**
+ * Simple HTTP proxy server with Basic authentication for testing.
+ *
+ * Usage:
+ *   node scripts/test-auth-proxy.js
+ *
+ * Then in X-Proxy extension:
+ *   Type: HTTP
+ *   Host: 127.0.0.1
+ *   Port: 18888
+ *   Username: testuser
+ *   Password: testpass
+ *
+ * The proxy forwards requests through your existing system connection.
+ * Press Ctrl+C to stop.
+ */
+
+import http from 'http';
+import net from 'net';
+
+const PORT = 18888;
+const USERNAME = 'testuser';
+const PASSWORD = 'testpass';
+
+function checkAuth(req) {
+  const authHeader = req.headers['proxy-authorization'];
+  if (!authHeader) return false;
+
+  const [scheme, encoded] = authHeader.split(' ');
+  if (scheme !== 'Basic') return false;
+
+  const decoded = Buffer.from(encoded, 'base64').toString();
+  const [user, pass] = decoded.split(':');
+  return user === USERNAME && pass === PASSWORD;
+}
+
+function send407(res) {
+  res.writeHead(407, {
+    'Proxy-Authenticate': 'Basic realm="Test Proxy"',
+    'Content-Type': 'text/plain'
+  });
+  res.end('Proxy Authentication Required');
+}
+
+const server = http.createServer((req, res) => {
+  // HTTP requests (non-CONNECT)
+  if (!checkAuth(req)) {
+    console.log(`[407] ${req.method} ${req.url} - auth required`);
+    return send407(res);
+  }
+
+  console.log(`[FWD] ${req.method} ${req.url}`);
+
+  const url = new URL(req.url);
+  const options = {
+    hostname: url.hostname,
+    port: url.port || 80,
+    path: url.pathname + url.search,
+    method: req.method,
+    headers: { ...req.headers }
+  };
+  delete options.headers['proxy-authorization'];
+  delete options.headers['proxy-connection'];
+
+  const proxy = http.request(options, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    proxyRes.pipe(res);
+  });
+
+  proxy.on('error', (err) => {
+    console.error(`[ERR] ${err.message}`);
+    res.writeHead(502);
+    res.end('Bad Gateway');
+  });
+
+  req.pipe(proxy);
+});
+
+// Handle CONNECT for HTTPS
+server.on('connect', (req, clientSocket, head) => {
+  if (!checkAuth(req)) {
+    console.log(`[407] CONNECT ${req.url} - auth required`);
+    clientSocket.write(
+      'HTTP/1.1 407 Proxy Authentication Required\r\n' +
+      'Proxy-Authenticate: Basic realm="Test Proxy"\r\n' +
+      '\r\n'
+    );
+    clientSocket.end();
+    return;
+  }
+
+  console.log(`[FWD] CONNECT ${req.url}`);
+
+  const [host, port] = req.url.split(':');
+  const serverSocket = net.connect(parseInt(port) || 443, host, () => {
+    clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+    serverSocket.write(head);
+    serverSocket.pipe(clientSocket);
+    clientSocket.pipe(serverSocket);
+  });
+
+  serverSocket.on('error', (err) => {
+    console.error(`[ERR] CONNECT ${req.url}: ${err.message}`);
+    clientSocket.end();
+  });
+
+  clientSocket.on('error', () => serverSocket.end());
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`\n  Auth Proxy running on 127.0.0.1:${PORT}`);
+  console.log(`  Username: ${USERNAME}`);
+  console.log(`  Password: ${PASSWORD}\n`);
+  console.log('  X-Proxy config:');
+  console.log('    Type: HTTP');
+  console.log('    Host: 127.0.0.1');
+  console.log('    Port: 18888');
+  console.log(`    Username: ${USERNAME}`);
+  console.log(`    Password: ${PASSWORD}\n`);
+  console.log('  Waiting for connections...\n');
+});

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Auth handler logic extracted from background.js for testing.
+ * This pure function handles proxy authentication via chrome.webRequest.onAuthRequired.
+ */
+function handleAuthRequired(details, activeProfile) {
+  if (!details.isProxy || !activeProfile) return {};
+  const auth = activeProfile.config?.auth;
+  if (!auth || !auth.username) return {};
+  return { authCredentials: { username: auth.username, password: auth.password } };
+}
+
+describe('handleAuthRequired', () => {
+  it('should return credentials when auth exists and isProxy is true', () => {
+    const details = { isProxy: true };
+    const profile = {
+      config: { auth: { username: 'user1', password: 'pass1' } }
+    };
+    const result = handleAuthRequired(details, profile);
+    expect(result).toEqual({
+      authCredentials: { username: 'user1', password: 'pass1' }
+    });
+  });
+
+  it('should return empty object when activeProfile is null', () => {
+    const details = { isProxy: true };
+    const result = handleAuthRequired(details, null);
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when username is empty', () => {
+    const details = { isProxy: true };
+    const profile = {
+      config: { auth: { username: '', password: '' } }
+    };
+    const result = handleAuthRequired(details, profile);
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when isProxy is false', () => {
+    const details = { isProxy: false };
+    const profile = {
+      config: { auth: { username: 'user1', password: 'pass1' } }
+    };
+    const result = handleAuthRequired(details, profile);
+    expect(result).toEqual({});
+  });
+
+  it('should return correct username and password values', () => {
+    const details = { isProxy: true };
+    const profile = {
+      config: { auth: { username: 'myuser', password: 'mypass123' } }
+    };
+    const result = handleAuthRequired(details, profile);
+    expect(result.authCredentials.username).toBe('myuser');
+    expect(result.authCredentials.password).toBe('mypass123');
+  });
+
+  it('should return empty object when auth is undefined', () => {
+    const details = { isProxy: true };
+    const profile = { config: {} };
+    const result = handleAuthRequired(details, profile);
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when config is undefined', () => {
+    const details = { isProxy: true };
+    const profile = {};
+    const result = handleAuthRequired(details, profile);
+    expect(result).toEqual({});
+  });
+});

--- a/tests/normalize.test.js
+++ b/tests/normalize.test.js
@@ -15,6 +15,7 @@ function normalizeProfile(profile) {
       type: profile.type || 'http',
       host: profile.host || '',
       port: parseInt(profile.port) || 8080,
+      auth: profile.config?.auth || { username: '', password: '' },
       bypassList: profile.bypassList || [],
       routingRules: profile.config?.routingRules || {
         enabled: false,
@@ -36,6 +37,7 @@ function normalizeProfileForSave(profile) {
       type: config.type || profile.type || 'http',
       host: config.host || profile.host || '',
       port: parseInt(config.port || profile.port) || 8080,
+      auth: config.auth || { username: '', password: '' },
       bypassList: config.bypassList || profile.bypassList || [],
       routingRules: config.routingRules || profile.routingRules || {
         enabled: false,
@@ -56,6 +58,7 @@ function popupNormalizeProfile(profile) {
       type: profile.config?.type || profile.type || 'http',
       host: profile.config?.host || profile.host || '',
       port: parseInt(profile.config?.port || profile.port) || 8080,
+      auth: profile.config?.auth || { username: '', password: '' },
       routingRules: profile.config?.routingRules || {
         enabled: false,
         mode: 'whitelist',
@@ -130,6 +133,65 @@ describe('normalizeProfile (options.js)', () => {
 
     expect(result.config.routingRules.mode).toBe('whitelist')
   })
+
+  it('should default auth to empty username and password', () => {
+    const profile = { id: '1', name: 'Test' }
+    const result = normalizeProfile(profile)
+
+    expect(result.config.auth).toEqual({ username: '', password: '' })
+  })
+
+  it('should preserve existing auth credentials', () => {
+    const profile = {
+      id: '1',
+      name: 'Test',
+      config: {
+        auth: { username: 'user1', password: 'pass1' }
+      }
+    }
+    const result = normalizeProfile(profile)
+
+    expect(result.config.auth).toEqual({ username: 'user1', password: 'pass1' })
+  })
+
+  it('should not lose auth after normalization round-trip', () => {
+    const original = {
+      id: '1',
+      name: 'Test',
+      config: {
+        auth: { username: 'myuser', password: 'mypass' }
+      }
+    }
+
+    const normalized = normalizeProfile(original)
+    const reloaded = normalizeProfile(normalized)
+
+    expect(reloaded.config.auth).toEqual({ username: 'myuser', password: 'mypass' })
+  })
+
+  it('should handle legacy profile without auth field (backward compat)', () => {
+    // Simulate a profile saved before auth feature existed (flat structure)
+    const legacy = {
+      id: '1',
+      name: 'Legacy Proxy',
+      type: 'socks5',
+      host: '127.0.0.1',
+      port: 1080
+      // no config, no auth — old flat format
+    }
+
+    const normalized = normalizeProfile(legacy)
+    expect(normalized.config.auth).toEqual({ username: '', password: '' })
+    expect(normalized.config.type).toBe('socks5')
+    expect(normalized.config.host).toBe('127.0.0.1')
+    expect(normalized.config.port).toBe(1080)
+
+    // Save preserves auth default
+    const saved = normalizeProfileForSave(normalized)
+    expect(saved.config.auth).toEqual({ username: '', password: '' })
+    expect(saved.config.type).toBe('socks5')
+    expect(saved.config.host).toBe('127.0.0.1')
+  })
 })
 
 describe('normalizeProfileForSave (options.js)', () => {
@@ -175,6 +237,26 @@ describe('normalizeProfileForSave (options.js)', () => {
     expect(result.config.routingRules.mode).toBe('blacklist')
     expect(result.config.routingRules.enabled).toBe(true)
   })
+
+  it('should include auth default values', () => {
+    const profile = { id: '1', name: 'Test' }
+    const result = normalizeProfileForSave(profile)
+
+    expect(result.config.auth).toEqual({ username: '', password: '' })
+  })
+
+  it('should preserve auth when saving', () => {
+    const profile = {
+      id: '1',
+      name: 'Test',
+      config: {
+        auth: { username: 'saveduser', password: 'savedpass' }
+      }
+    }
+    const result = normalizeProfileForSave(profile)
+
+    expect(result.config.auth).toEqual({ username: 'saveduser', password: 'savedpass' })
+  })
 })
 
 describe('normalizeProfile (popup.js)', () => {
@@ -204,5 +286,43 @@ describe('normalizeProfile (popup.js)', () => {
     const result = popupNormalizeProfile(profile)
 
     expect(result.config.routingRules.mode).toBe('blacklist')
+  })
+
+  it('should default auth to empty username and password', () => {
+    const profile = { id: '1', name: 'Test' }
+    const result = popupNormalizeProfile(profile)
+
+    expect(result.config.auth).toEqual({ username: '', password: '' })
+  })
+
+  it('should preserve auth from config.auth', () => {
+    const profile = {
+      id: '1',
+      name: 'Test',
+      config: {
+        auth: { username: 'popupuser', password: 'popuppass' }
+      }
+    }
+    const result = popupNormalizeProfile(profile)
+
+    expect(result.config.auth).toEqual({ username: 'popupuser', password: 'popuppass' })
+  })
+
+  it('should handle legacy profile without auth in popup (backward compat)', () => {
+    const legacy = {
+      id: '1',
+      name: 'Old Profile',
+      config: {
+        type: 'http',
+        host: 'proxy.example.com',
+        port: 8080,
+        routingRules: { enabled: true, mode: 'whitelist', domains: ['*.google.com'] }
+      }
+    }
+    const result = popupNormalizeProfile(legacy)
+
+    expect(result.config.auth).toEqual({ username: '', password: '' })
+    expect(result.config.host).toBe('proxy.example.com')
+    expect(result.config.routingRules.enabled).toBe(true)
   })
 })


### PR DESCRIPTION
Add username/password authentication for proxy servers via chrome.webRequest.onAuthRequired with asyncBlocking mode to survive service worker restarts. Includes auth UI in options page with show/hide password toggle, backward-compatible normalization, and 36 unit tests (TDD).