### PR TITLE
feat: improve visuals of popup in darkmode

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -35,7 +35,13 @@
     --surface: #F2F2F7;
     --surface-hover: rgba(0, 0, 0, 0.04);
     --surface-active: rgba(0, 122, 255, 0.08);
-    
+
+    /* Glass and gradient accent backgrounds */
+    --glass-bg: rgba(255, 255, 255, 0.8);
+    --glass-btn-bg: rgba(255, 255, 255, 0.6);
+    --surface-bright: rgba(255, 255, 255, 0.9);
+    --surface-brightest: rgba(255, 255, 255, 1);
+
     /* Borders */
     --border-color: rgba(60, 60, 67, 0.12);
     --border-hover: rgba(60, 60, 67, 0.2);
@@ -48,6 +54,7 @@
     --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.1), 0 4px 8px rgba(0, 0, 0, 0.04);
     --shadow-xl: 0 12px 24px rgba(0, 0, 0, 0.12), 0 6px 12px rgba(0, 0, 0, 0.04);
     --shadow-glow: 0 0 20px rgba(0, 122, 255, 0.15);
+    --shadow-medium: 0 4px 12px rgba(0, 0, 0, 0.12);
     
     /* Transitions & Animations */
     --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -72,15 +79,26 @@
 @media (prefers-color-scheme: dark) {
     :root {
         --background: #000000;
+        --background-secondary: #1C1C1E;
         --surface: #1C1C1E;
         --surface-hover: #2C2C2E;
+        --surface-active: rgba(0, 122, 255, 0.12);
+        --glass-bg: rgba(28, 28, 30, 0.9);
+        --glass-btn-bg: rgba(44, 44, 46, 0.6);
+        --surface-bright: rgba(44, 44, 46, 0.9);
+        --surface-brightest: rgba(44, 44, 46, 1);
         --text-primary: #FFFFFF;
         --text-secondary: #8E8E93;
         --text-tertiary: #48484A;
         --border-color: #38383A;
-        --shadow-light: 0 1px 3px rgba(0, 0, 0, 0.3);
+        --border-hover: #48484A;
+        --divider: rgba(255, 255, 255, 0.08);
+        --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.2);
+        --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
+        --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2);
+        --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.5), 0 4px 8px rgba(0, 0, 0, 0.2);
+        --shadow-xl: 0 12px 24px rgba(0, 0, 0, 0.6), 0 6px 12px rgba(0, 0, 0, 0.2);
         --shadow-medium: 0 4px 12px rgba(0, 0, 0, 0.4);
-        --shadow-heavy: 0 8px 24px rgba(0, 0, 0, 0.5);
     }
 }
 
@@ -130,7 +148,7 @@ body::before {
 /* Header Styles */
 .header {
     padding: var(--space-lg);
-    background: rgba(255, 255, 255, 0.8);
+    background: var(--glass-bg);
     border-bottom: 1px solid var(--border-color);
     position: sticky;
     top: 0;
@@ -156,7 +174,7 @@ body::before {
     align-items: center;
     gap: var(--space-sm);
     padding: 6px 12px;
-    background: linear-gradient(135deg, var(--surface) 0%, rgba(255, 255, 255, 0.8) 100%);
+    background: linear-gradient(135deg, var(--surface) 0%, var(--glass-bg) 100%);
     border: 1px solid var(--border-color);
     border-radius: 20px;
     transition: all var(--transition-base);
@@ -210,7 +228,7 @@ body::before {
     width: 32px;
     height: 32px;
     border: none;
-    background: rgba(255, 255, 255, 0.6);
+    background: var(--glass-btn-bg);
     color: var(--text-secondary);
     border-radius: 8px;
     cursor: pointer;
@@ -264,7 +282,7 @@ body::before {
     align-items: center;
     gap: var(--space-md);
     padding: var(--space-md);
-    background: linear-gradient(135deg, var(--surface) 0%, rgba(255, 255, 255, 0.9) 100%);
+    background: linear-gradient(135deg, var(--surface) 0%, var(--surface-bright) 100%);
     border: 1px solid var(--border-color);
     border-radius: 12px;
     cursor: pointer;
@@ -290,7 +308,7 @@ body::before {
 }
 
 .action-card:hover {
-    background: linear-gradient(135deg, rgba(255, 255, 255, 1) 0%, var(--surface) 100%);
+    background: linear-gradient(135deg, var(--surface-brightest) 0%, var(--surface) 100%);
     transform: translateY(-2px) scale(1.02);
     box-shadow: var(--shadow-md);
     border-color: var(--primary-color);
@@ -331,7 +349,7 @@ body::before {
     align-items: center;
     justify-content: center;
     color: var(--primary-color);
-    background: linear-gradient(135deg, var(--background) 0%, rgba(255, 255, 255, 0.9) 100%);
+    background: linear-gradient(135deg, var(--background) 0%, var(--surface-bright) 100%);
     border-radius: 10px;
     transition: all var(--transition-base);
     box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05);
@@ -480,7 +498,7 @@ body::before {
     align-items: center;
     gap: var(--space-md);
     padding: var(--space-sm) var(--space-md);
-    background: linear-gradient(135deg, var(--surface) 0%, rgba(255, 255, 255, 0.8) 100%);
+    background: linear-gradient(135deg, var(--surface) 0%, var(--glass-bg) 100%);
     border: 1px solid var(--border-color);
     border-radius: 10px;
     cursor: pointer;
@@ -502,7 +520,7 @@ body::before {
 }
 
 .profile-item:hover {
-    background: linear-gradient(135deg, rgba(255, 255, 255, 1) 0%, var(--surface) 100%);
+    background: linear-gradient(135deg, var(--surface-brightest) 0%, var(--surface) 100%);
     transform: scale(1.01);
     box-shadow: var(--shadow-md);
     border-color: var(--primary-color);
@@ -528,7 +546,7 @@ body::before {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, var(--background) 0%, rgba(255, 255, 255, 0.9) 100%);
+    background: linear-gradient(135deg, var(--background) 0%, var(--surface-bright) 100%);
     border-radius: 8px;
     color: var(--primary-color);
     transition: all var(--transition-base);
@@ -639,7 +657,7 @@ body::before {
     justify-content: center;
     gap: var(--space-lg);
     padding: var(--space-md) var(--space-lg);
-    background: rgba(255, 255, 255, 0.8);
+    background: var(--glass-bg);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     border-top: 1px solid var(--border-color);


### PR DESCRIPTION
# Fix dark mode in popup

The popup appeared light in dark mode due to hardcoded `rgba(255, 255, 255, ...)` values throughout `popup.css` that the `@media (prefers-color-scheme: dark)` block couldn't override. The dark mode block also used wrong shadow variable names (`--shadow-light/medium/heavy` instead of `--shadow-xs/sm/md/lg/xl`) and was missing overrides for `--background-secondary`, `--border-hover`, and `--divider`.

**Changes in `popup.css`:**
- Extracted hardcoded white values into CSS variables (`--glass-bg`, `--glass-btn-bg`, `--surface-bright`, `--surface-brightest`)
- Expanded the dark mode block to override all these variables and fix shadow variable names
- Added missing variable overrides for `--background-secondary`, `--border-hover`, `--divider`, `--surface-active`

**before:**
<img width="326" height="503" alt="before" src="https://github.com/user-attachments/assets/e8d9da17-cd40-45d0-b2c7-b0e6d5d43649" />

**after:**
<img width="327" height="505" alt="after" src="https://github.com/user-attachments/assets/e3eba663-daac-4a27-88ab-9ae6d1a2c8d3" />