### PR TITLE
fix: sync package-lock.json version to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x-proxy",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x-proxy",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.59.1",


### PR DESCRIPTION
The lockfile version field was not updated in PR #24's version bump. Syncs package-lock.json to match package.json v1.5.1.

https://claude.ai/code/session_01EbPWify3BSwXKAie6gWbzn