### PR TITLE
feat(pages): migrate GitHub Pages to custom domain x-proxy.i-am-holo.top

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
   <a href="https://github.com/helebest/x-proxy/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/helebest/x-proxy/releases"><img src="https://img.shields.io/github/v/release/helebest/x-proxy" alt="Release"></a>
   <a href="https://github.com/helebest/x-proxy/stargazers"><img src="https://img.shields.io/github/stars/helebest/x-proxy?style=social" alt="Stars"></a>
-  <a href="https://helebest.github.io/x-proxy/"><img src="https://img.shields.io/badge/website-online-brightgreen" alt="Website"></a>
+  <a href="https://x-proxy.i-am-holo.top/"><img src="https://img.shields.io/badge/website-online-brightgreen" alt="Website"></a>
 </p>
 
 <p align="center">
-  <a href="https://helebest.github.io/x-proxy/">Website</a> •
+  <a href="https://x-proxy.i-am-holo.top/">Website</a> •
   <a href="#-features">Features</a> •
   <a href="#-installation">Installation</a> •
   <a href="#-quick-start">Quick Start</a> •
@@ -264,7 +264,7 @@ Your privacy is important:
 - ✅ **Open Source** - Audit the entire codebase
 - ✅ **Minimal Permissions** - Only `proxy` and `storage` required
 
-Read our [Privacy Policy](https://helebest.github.io/x-proxy/PRIVACY_POLICY/) for details.
+Read our [Privacy Policy](https://x-proxy.i-am-holo.top/PRIVACY_POLICY/) for details.
 
 ## 📄 License
 
@@ -274,7 +274,7 @@ This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) 
 
 ## 🌐 Links
 
-- **Website**: https://helebest.github.io/x-proxy/
+- **Website**: https://x-proxy.i-am-holo.top/
 - **Issues**: https://github.com/helebest/x-proxy/issues
 - **Discussions**: https://github.com/helebest/x-proxy/discussions
 - **Changelog**: [CHANGELOG.md](CHANGELOG.md)

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+x-proxy.i-am-holo.top

--- a/docs/PRIVACY_POLICY/index.html
+++ b/docs/PRIVACY_POLICY/index.html
@@ -17,24 +17,24 @@
     </script>
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://helebest.github.io/x-proxy/PRIVACY_POLICY/">
+    <link rel="canonical" href="https://x-proxy.i-am-holo.top/PRIVACY_POLICY/">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://helebest.github.io/x-proxy/PRIVACY_POLICY/">
+    <meta property="og:url" content="https://x-proxy.i-am-holo.top/PRIVACY_POLICY/">
     <meta property="og:title" content="Privacy Policy - X-Proxy">
     <meta property="og:description" content="X-Proxy privacy policy: All data stored locally, no tracking, no external servers.">
-    <meta property="og:image" content="https://helebest.github.io/x-proxy/assets/images/og-image.png">
+    <meta property="og:image" content="https://x-proxy.i-am-holo.top/assets/images/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:type" content="image/png">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:url" content="https://helebest.github.io/x-proxy/PRIVACY_POLICY/">
+    <meta name="twitter:url" content="https://x-proxy.i-am-holo.top/PRIVACY_POLICY/">
     <meta name="twitter:title" content="Privacy Policy - X-Proxy">
     <meta name="twitter:description" content="X-Proxy privacy policy: All data stored locally, no tracking, no external servers.">
-    <meta name="twitter:image" content="https://helebest.github.io/x-proxy/assets/images/og-image.png">
+    <meta name="twitter:image" content="https://x-proxy.i-am-holo.top/assets/images/og-image.png">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/icon-32.png">

--- a/docs/SEO_GUIDE.md
+++ b/docs/SEO_GUIDE.md
@@ -140,7 +140,7 @@ docs/
 #### 1.1 Google Search Console设置 ⚡ 高优先级
 - [x] ✅ 创建Google Search Console验证文件 (`google3524193870f730e6.html`)
 - [x] ✅ 已提交到Google Search Console并完成验证
-- [x] ✅ 已提交sitemap: `https://helebest.github.io/x-proxy/sitemap.xml`
+- [x] ✅ 已提交sitemap: `https://x-proxy.i-am-holo.top/sitemap.xml`
 - [ ] 监控索引状态（等待Google抓取，通常需要24-48小时）
 - [ ] 检查爬虫错误
 - [ ] 验证移动设备友好性测试结果
@@ -226,10 +226,10 @@ docs/
 **实施方式**:
 ```html
 <!-- 添加hreflang标签 -->
-<link rel="alternate" hreflang="en" href="https://helebest.github.io/x-proxy/" />
-<link rel="alternate" hreflang="zh" href="https://helebest.github.io/x-proxy/zh/" />
-<link rel="alternate" hreflang="ja" href="https://helebest.github.io/x-proxy/ja/" />
-<link rel="alternate" hreflang="ru" href="https://helebest.github.io/x-proxy/ru/" />
+<link rel="alternate" hreflang="en" href="https://x-proxy.i-am-holo.top/" />
+<link rel="alternate" hreflang="zh" href="https://x-proxy.i-am-holo.top/zh/" />
+<link rel="alternate" hreflang="ja" href="https://x-proxy.i-am-holo.top/ja/" />
+<link rel="alternate" hreflang="ru" href="https://x-proxy.i-am-holo.top/ru/" />
 ```
 
 ### Phase 3: 外链建设（持续进行）
@@ -361,8 +361,8 @@ docs/
 ## 📋 验证清单
 
 ### 发布前验证
-- [x] ✅ Sitemap可访问: https://helebest.github.io/x-proxy/sitemap.xml
-- [x] ✅ Robots.txt可访问: https://helebest.github.io/x-proxy/robots.txt
+- [x] ✅ Sitemap可访问: https://x-proxy.i-am-holo.top/sitemap.xml
+- [x] ✅ Robots.txt可访问: https://x-proxy.i-am-holo.top/robots.txt
 - [ ] Schema.org标记有效（使用Google Rich Results Test）- 需验证
 - [ ] Open Graph标签正确显示（使用Facebook Debugger）- 需验证
 - [ ] 所有链接正常（无404错误）- 需测试
@@ -416,10 +416,10 @@ docs/
 ## 🚀 快速参考
 
 ### 重要URL
-- **网站**: https://helebest.github.io/x-proxy/
+- **网站**: https://x-proxy.i-am-holo.top/
 - **GitHub仓库**: https://github.com/helebest/x-proxy
-- **Sitemap**: https://helebest.github.io/x-proxy/sitemap.xml
-- **隐私政策**: https://helebest.github.io/x-proxy/PRIVACY_POLICY/
+- **Sitemap**: https://x-proxy.i-am-holo.top/sitemap.xml
+- **隐私政策**: https://x-proxy.i-am-holo.top/PRIVACY_POLICY/
 - **Chrome商店**: https://chromewebstore.google.com/detail/x-proxy/efbckpjdlnojgnggdilgddeemgkoccaf
 
 ### 技术支持

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,14 +17,14 @@
     </script>
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://helebest.github.io/x-proxy/">
+    <link rel="canonical" href="https://x-proxy.i-am-holo.top/">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://helebest.github.io/x-proxy/">
+    <meta property="og:url" content="https://x-proxy.i-am-holo.top/">
     <meta property="og:title" content="X-Proxy - Free Chrome Proxy Switcher | HTTP & SOCKS5">
     <meta property="og:description" content="Free, open-source Chrome proxy switcher. Quick switching between HTTP, HTTPS, SOCKS5 proxies, and PAC files. Simple, fast, and privacy-focused.">
-    <meta property="og:image" content="https://helebest.github.io/x-proxy/assets/images/og-image.png">
+    <meta property="og:image" content="https://x-proxy.i-am-holo.top/assets/images/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:type" content="image/png">
@@ -32,10 +32,10 @@
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:url" content="https://helebest.github.io/x-proxy/">
+    <meta name="twitter:url" content="https://x-proxy.i-am-holo.top/">
     <meta name="twitter:title" content="X-Proxy - Free Chrome Proxy Switcher">
     <meta name="twitter:description" content="Free Chrome proxy switcher with HTTP, HTTPS, SOCKS5, and PAC file support. Quick switching, profile management, open-source.">
-    <meta name="twitter:image" content="https://helebest.github.io/x-proxy/assets/images/og-image.png">
+    <meta name="twitter:image" content="https://x-proxy.i-am-holo.top/assets/images/og-image.png">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="32x32" href="icons/icon-32.png">
@@ -89,7 +89,7 @@
         "Open Source",
         "Free Forever"
       ],
-      "screenshot": "https://helebest.github.io/x-proxy/icons/icon-128.png",
+      "screenshot": "https://x-proxy.i-am-holo.top/icons/icon-128.png",
       "softwareHelp": {
         "@type": "WebPage",
         "url": "https://github.com/helebest/x-proxy#readme"
@@ -1069,7 +1069,7 @@ npm run build
     </script>
 
     <!-- Structured Data Validation: https://search.google.com/test/rich-results -->
-    <!-- Sitemap: https://helebest.github.io/x-proxy/sitemap.xml -->
+    <!-- Sitemap: https://x-proxy.i-am-holo.top/sitemap.xml -->
     <!-- Submit to Google Search Console: https://search.google.com/search-console -->
 </body>
 </html>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -5,7 +5,7 @@ User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://helebest.github.io/x-proxy/sitemap.xml
+Sitemap: https://x-proxy.i-am-holo.top/sitemap.xml
 
 # Disallow crawling of assets directory (optional)
 # Uncomment if you want to prevent indexing of images/css/js

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -6,16 +6,16 @@
 
     <!-- Homepage - Highest Priority -->
     <url>
-        <loc>https://helebest.github.io/x-proxy/</loc>
-        <lastmod>2026-03-06</lastmod>
+        <loc>https://x-proxy.i-am-holo.top/</loc>
+        <lastmod>2026-04-20</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <!-- Privacy Policy -->
     <url>
-        <loc>https://helebest.github.io/x-proxy/PRIVACY_POLICY/</loc>
-        <lastmod>2025-10-01</lastmod>
+        <loc>https://x-proxy.i-am-holo.top/PRIVACY_POLICY/</loc>
+        <lastmod>2026-04-20</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>


### PR DESCRIPTION
## Summary

- Add `docs/CNAME` → triggers GitHub Pages to serve the site at `https://x-proxy.i-am-holo.top/` and permanently 301-redirect `helebest.github.io/x-proxy/*` to the new domain.
- Update all self-referencing URLs (canonical / OG / Twitter / JSON-LD / sitemap / robots) from `helebest.github.io/x-proxy` to `x-proxy.i-am-holo.top` so crawlers, social previews, and search engines resolve consistently after cutover.
- Update README and `docs/SEO_GUIDE.md` links.

## SEO impact

GitHub's automatic 301 from the old URL passes link equity to the new domain, which is the standard Google-recommended mechanism for domain moves. Expected timeline: 2–8 weeks for full index migration.

**Do not rename the repo `x-proxy`** — that would break the 301 and lose accrued SEO value.

## Files changed

| Type | File |
|---|---|
| New | `docs/CNAME` |
| SEO-critical | `docs/index.html`, `docs/PRIVACY_POLICY/index.html`, `docs/sitemap.xml`, `docs/robots.txt` |
| Docs/README | `README.md`, `docs/SEO_GUIDE.md` |
| Left alone | `docs/google3524193870f730e6.html` (reused to verify new domain in GSC), all `github.com/helebest/x-proxy` repo links |

## Merge order (important)

1. Add the `CNAME` record at the DNS provider for `i-am-holo.top`:
   ```
   x-proxy  CNAME  helebest.github.io
   ```
2. Wait for DNS propagation (`dig x-proxy.i-am-holo.top` resolves to github.io IPs).
3. **Then** merge this PR. GitHub auto-activates the custom domain on merge.
4. In repo Settings → Pages, verify Custom domain = `x-proxy.i-am-holo.top`, then enable **Enforce HTTPS** (wait a few minutes for the cert).
5. In Google Search Console:
   - Add new property for `https://x-proxy.i-am-holo.top/`, re-verify via existing `google3524193870f730e6.html`.
   - On the **old** property, use Settings → Change of Address → point to new property.
   - Submit the new sitemap `https://x-proxy.i-am-holo.top/sitemap.xml`.
   - Keep the old property active for monitoring.

## Test plan

- [ ] After merge + DNS: `curl -I https://helebest.github.io/x-proxy/` returns `301` → new domain
- [ ] `https://x-proxy.i-am-holo.top/` loads with all assets (icons/CSS via relative paths)
- [ ] Page source `canonical`, `og:url`, `twitter:url` all point to new domain
- [ ] `https://x-proxy.i-am-holo.top/sitemap.xml` and `/robots.txt` serve updated content
- [ ] `https://x-proxy.i-am-holo.top/google3524193870f730e6.html` reachable (for GSC re-verification)
- [ ] HTTPS enforced (browser lock icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)