### PR TITLE
fix(ui): remove backdrop-filter blur for low-end hardware (#27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ node_modules
 coverage
 *.lcov
 .nyc_output
+test-results
+playwright-report
 
 # Production build
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated: 2026-04-16
+Last updated: 2026-04-20
 
 All notable changes to X-Proxy Chrome Extension will be documented in this file.
 
@@ -14,6 +14,17 @@ Future improvements planned:
 - Performance optimizations
 - Blog content creation for SEO
 - Multi-language support (Chinese, Japanese, Russian)
+
+## [1.5.2] - 2026-04-20
+
+### Fixed
+- **Performance**: Removed `backdrop-filter: blur()` from options modal, options header/sidebar, and popup header/footer. Fixes severe UI lag on low-end hardware without GPU acceleration (reported on Windows 7 without dedicated GPU, where switching between form fields in the Add Profile dialog could take several seconds). Modal overlay opacity bumped from `rgba(0,0,0,0.4)` to `rgba(0,0,0,0.55)` to preserve visual separation. ([#27](https://github.com/helebest/x-proxy/issues/27))
+
+### Added
+- **Regression guard**: New Playwright spec `e2e/no-blur.spec.ts` asserts `backdrop-filter: none` on all five previously-blurred surfaces, so nobody can quietly reintroduce blur.
+
+### Credits
+- Thanks to [@sergeevabc](https://github.com/sergeevabc) for reporting issue #27.
 
 ## [1.5.1] - 2026-04-16
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,11 @@ If you find X-Proxy useful, consider:
 - [x] Dark mode UI improvements
 - [x] Vite security upgrade (v6.4.2)
 
+### v1.5.2 ✅ (Performance)
+- [x] Removed `backdrop-filter: blur()` from options modal, options header/sidebar, and popup header/footer — fixes UI lag on low-end hardware without GPU acceleration ([#27](https://github.com/helebest/x-proxy/issues/27))
+- [x] Darker modal overlay (`rgba(0,0,0,0.55)`) preserves visual separation without compositor cost
+- [x] New Playwright regression guard prevents `backdrop-filter` from slipping back in
+
 ### v2.0.0 (Future)
 - [ ] Profile sharing via URL
 - [ ] Connection testing

--- a/docs/STORE_LISTING.md
+++ b/docs/STORE_LISTING.md
@@ -88,12 +88,12 @@ X-Proxy respects your privacy:
 
 ### 🔄 Current Version
 
-**Version 1.5.1** - Visual Enhancements
-• Dynamic toolbar icon color matching active profile
-• Dark mode UI improvements
-• Security upgrade (Vite v6.4.2)
+**Version 1.5.2** - Performance
+• Removed backdrop blur effect for smooth UI on low-end hardware (no GPU required)
+• Darker modal overlay preserves visual separation without compositor cost
 
 **Previous Updates:**
+• v1.5.1: Dynamic toolbar icon colors, dark mode polish
 • v1.5.0: PAC (Proxy Auto-Configuration) file support
 • v1.4.2: Proxy authentication (username/password)
 • v1.4.0: Import/Export profiles as JSON

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@
         "worstRating": "1"
       },
       "description": "Free Chrome proxy switcher with HTTP, HTTPS, SOCKS5, and PAC file support. Quick switching, profile management, and privacy-focused design.",
-      "softwareVersion": "1.5.1",
+      "softwareVersion": "1.5.2",
       "author": {
         "@type": "Person",
         "name": "helebest",

--- a/e2e/no-blur.spec.ts
+++ b/e2e/no-blur.spec.ts
@@ -1,0 +1,27 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixture'
+
+async function expectNoBackdropBlur(page: Page, selector: string, label: string) {
+  const probe = await page.locator(selector).evaluate((el) => {
+    const s = getComputedStyle(el as Element) as CSSStyleDeclaration & { webkitBackdropFilter?: string }
+    return { std: s.backdropFilter || 'none', webkit: s.webkitBackdropFilter || 'none' }
+  })
+  expect(probe.std, `${label} backdrop-filter`).toBe('none')
+  expect(probe.webkit, `${label} -webkit-backdrop-filter`).toBe('none')
+}
+
+test.describe('Issue #27 — no backdrop-filter blur anywhere', () => {
+  test('options page surfaces have no backdrop blur', async ({ optionsPage }) => {
+    await expectNoBackdropBlur(optionsPage, '.header', 'options .header')
+    await expectNoBackdropBlur(optionsPage, '.sidebar', 'options .sidebar')
+
+    await optionsPage.click('#addProfileBtn')
+    await expect(optionsPage.locator('#profileModal')).toHaveClass(/show/)
+    await expectNoBackdropBlur(optionsPage, '#profileModal', 'options #profileModal')
+  })
+
+  test('popup surfaces have no backdrop blur', async ({ popupPage }) => {
+    await expectNoBackdropBlur(popupPage, '.header', 'popup .header')
+    await expectNoBackdropBlur(popupPage, '.footer', 'popup .footer')
+  })
+})

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -462,7 +462,7 @@ test.describe('Options Page - About Section', () => {
   test('should navigate to About section', async ({ optionsPage }) => {
     await optionsPage.click('[data-section="about"]')
     await expect(optionsPage.locator('#about-section')).toBeVisible()
-    await expect(optionsPage.locator('#about-section')).toContainText('X-Proxy v1.5.1')
+    await expect(optionsPage.locator('#about-section')).toContainText('X-Proxy v1.5.2')
   })
 
   test('should show feature list', async ({ optionsPage }) => {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "X-Proxy",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A modern proxy switcher for Chrome with HTTP(S) and SOCKS5 support",
   "permissions": [
     "proxy",

--- a/options.css
+++ b/options.css
@@ -174,8 +174,6 @@ html {
 /* Header */
 .header {
   background: rgba(255, 255, 255, 0.8);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
   border-bottom: 1px solid var(--border-color);
   position: fixed;
   top: 0;
@@ -248,8 +246,6 @@ html {
 .sidebar {
   width: var(--sidebar-width);
   background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
   border-right: 1px solid var(--border-color);
   position: fixed;
   left: 0;
@@ -1104,9 +1100,7 @@ html {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  background: rgba(0, 0, 0, 0.55);
   z-index: var(--z-modal);
   animation: fadeIn var(--transition-base) var(--ease-out);
 }

--- a/options.html
+++ b/options.html
@@ -69,7 +69,7 @@
             </div>
             
             <div class="about-info">
-              <h3>X-Proxy v1.5.1</h3>
+              <h3>X-Proxy v1.5.2</h3>
               <p>A modern proxy switcher for Chrome with HTTP(S), SOCKS5, and PAC support</p>
 
               <div class="about-details">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x-proxy",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x-proxy",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-proxy",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/popup.css
+++ b/popup.css
@@ -153,8 +153,6 @@ body::before {
     position: sticky;
     top: 0;
     z-index: 100;
-    backdrop-filter: blur(20px) saturate(180%);
-    -webkit-backdrop-filter: blur(20px) saturate(180%);
     box-shadow: var(--shadow-sm);
     transition: all var(--transition-base);
 }
@@ -658,8 +656,6 @@ body::before {
     gap: var(--space-lg);
     padding: var(--space-md) var(--space-lg);
     background: var(--glass-bg);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
     border-top: 1px solid var(--border-color);
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
 }


### PR DESCRIPTION
## Summary

- Removes `backdrop-filter: blur()` from all 5 surfaces in the extension — options modal overlay, options header/sidebar, popup header/footer. Blur forces a full-viewport compositor re-rasterize every paint; on hardware without GPU acceleration, focus transitions inside the Add Profile dialog stalled for seconds.
- Modal overlay bumped `rgba(0,0,0,0.4)` → `rgba(0,0,0,0.55)` to preserve the dialog's visual separation from the page.
- Adds `e2e/no-blur.spec.ts` as a regression guard (2 tests, ~3.3s) that asserts `backdrop-filter: none` on every previously-blurred surface via real Chromium through the existing Playwright extension fixture.
- Bumps version `1.5.1` → `1.5.2` and syncs `manifest.json`, `package.json`, `package-lock.json`, options About page, `docs/index.html` JSON-LD, `docs/STORE_LISTING.md`, `README.md`, `CHANGELOG.md`.
- Gitignores `test-results/` and `playwright-report/` so Playwright artifacts stop showing up in `git status`.

Closes #27 — thanks to @sergeevabc for the report.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run build` — all 3 targets build
- [x] `npm test` — Vitest 71/71
- [x] `npm run test:e2e` — Playwright 50/50 in real Chromium with the extension loaded
- [x] TDD RED verified: new spec initially failed on all 5 surfaces reporting the exact `blur(8px)` / `blur(20px) saturate(1.8)` / etc. values
- [x] TDD GREEN verified: same spec passes after CSS removal
- [x] Visual regression baselines (`e2e/visual.spec.ts`) stay within the existing 5% pixel tolerance — no baseline refresh needed
- [x] Version string lands in manifest, About page, JSON-LD, store listing, README, CHANGELOG
- [x] Manual Chrome smoke: Add Profile modal shows solid dark overlay, field focus is instant, popup header/footer still legible